### PR TITLE
Remaining available slots are now added to the image upload grid feat

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,10 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: "https",
+        hostname: "via.placeholder.com",
+      },
+      {
+        protocol: "https",
         hostname: "originotesdev.s3.us-east-1.amazonaws.com",
       },
       {

--- a/src/app/(routes)/vendor/listings/service-editor/create-listing-form.tsx
+++ b/src/app/(routes)/vendor/listings/service-editor/create-listing-form.tsx
@@ -70,7 +70,7 @@ export const CreateListingForm = ({
   categories: Category[];
 }) => {
   const [state, formAction] = useFormState(submitNewService, initialState);
-  console.log('server issues????: ', state?.issues);
+
   const form = useForm<z.infer<typeof ServiceListingSchema>>({
     mode: "onChange",
     resolver: zodResolver(ServiceListingSchema),
@@ -119,7 +119,7 @@ export const CreateListingForm = ({
   };
   const formRef = useRef<HTMLFormElement>(null);
   const { errors } = form.formState;
-  console.log("client errors: ", errors);
+
 
   return (
     <Form {...form}>

--- a/src/app/(routes)/vendor/listings/service-editor/image-grid.tsx
+++ b/src/app/(routes)/vendor/listings/service-editor/image-grid.tsx
@@ -12,7 +12,7 @@ export const ImageGrid = ({
   uploadBtn,
 }: {
   isUploading: boolean;
-  files: (S3File | File | CustomSwellFile)[];
+  files: (S3File | File | CustomSwellFile | null)[];
   uploadBtn: {
     rootProps: any;
     inputProps: any;
@@ -52,7 +52,8 @@ export const ImageGrid = ({
           </li>
         ) : firstImage &&
           typeof firstImage === "object" &&
-          "data" in firstImage && firstImage.status === 200 ? (
+          "data" in firstImage &&
+          firstImage.status === 200 ? (
           <li className="size-full">
             <div className="aspect-h-7 aspect-w-10 group relative block size-full overflow-hidden rounded-lg border border-neutral-300">
               <Image
@@ -76,11 +77,13 @@ export const ImageGrid = ({
               />
             </div>
           </li>
-        ) : (<li className="size-full">
-          <div className="aspect-h-7 aspect-w-10 group relative block size-full overflow-hidden rounded-lg border border-neutral-300">
-            <p className="text-red-500">Image failed to upload</p>
-          </div>
-        </li >)}
+        ) : (
+          <li className="size-full">
+            <div className="aspect-h-7 aspect-w-10 group relative block size-full overflow-hidden rounded-lg border border-neutral-300">
+              <p className="text-red-500">Image failed to upload</p>
+            </div>
+          </li>
+        )}
       </ul>
       <ul role="list" className="grid grid-cols-3 gap-2">
         {rest.length > 0 &&
@@ -92,9 +95,7 @@ export const ImageGrid = ({
                     <div className="flex size-full items-center justify-center">
                       <RiImageAddFill className="size-8 text-neutral-300 dark:text-neutral-200" />
                     </div>
-
                     <GridUploadInput
-
                       getRootProps={uploadBtn.rootProps}
                       getInputProps={uploadBtn.inputProps}
                     />
@@ -103,21 +104,25 @@ export const ImageGrid = ({
               );
             }
 
-            if (typeof elem === "object" && "data" in elem && elem.status === 200) {
-              return (
-                <li className="size-full" key={elem.data.url}>
-                  <div className="aspect-h-7 aspect-w-10 group block size-full overflow-hidden rounded-lg border border-neutral-300">
-                    <Image
-                      width={elem.data.width}
-                      height={elem.data.height}
-                      src={elem.data.url!}
-                      alt=""
-                      className="pointer-events-none object-cover group-hover:opacity-75"
-                    />
-                  </div>
-                </li>
-              );
-            }
+            // if (
+            //   typeof elem === "object" &&
+            //   "data" in elem &&
+            //   elem.status === 200
+            // ) {
+            //   return (
+            //     <li className="size-full" key={elem.data.url}>
+            //       <div className="aspect-h-7 aspect-w-10 group block size-full overflow-hidden rounded-lg border border-neutral-300">
+            //         <Image
+            //           width={elem.data.width}
+            //           height={elem.data.height}
+            //           src={elem.data.url!}
+            //           alt=""
+            //           className="pointer-events-none object-cover group-hover:opacity-75"
+            //         />
+            //       </div>
+            //     </li>
+            //   );
+            // }
 
             if ("url" in elem) {
               return (

--- a/src/app/(routes)/vendor/listings/service-editor/listing-file-upload.tsx
+++ b/src/app/(routes)/vendor/listings/service-editor/listing-file-upload.tsx
@@ -56,7 +56,7 @@ export function ListingFileUpload({
                   className="sr-only"
                 />
               </label>
-              <p className={serverErrors?.service_image_file || clientErrors?.uploaded_service_files ? "pl-1 font-medium text-neutral-800" : "pl-1 font-medium text-neutral-200"}>&nbsp;or drag and drop</p>
+              <p className={serverErrors?.service_image_file || clientErrors?.uploaded_service_files ? "pl-1 font-medium text-neutral-800" : "pl-1 font-medium dark:text-neutral-200"}>&nbsp;or drag and drop</p>
             </div>
             <p className={serverErrors?.service_image_file || clientErrors?.uploaded_service_files ? "mt-2 text-xs font-medium leading-5 text-neutral-800" : "mt-2 text-xs leading-5 text-neutral-600 dark:text-neutral-200"}>
               PNG, JPG, MP4, JPEG and more are accepted


### PR DESCRIPTION
chore: remaining "dumb" inputs are now added dynamically to the image grid upload feat.

If a user selects less than 10 images, the remaining available slots will be filled with null, which will be used to replace them by an input of `type="file"`