### PR TITLE
chore: Files retrieved from products

### DIFF
--- a/src/app/(routes)/vendor/listings/page.tsx
+++ b/src/app/(routes)/vendor/listings/page.tsx
@@ -16,7 +16,7 @@ export default async function VendorListings({
   const page = searchParams.page ? parseInt(searchParams.page as string) : 1;
   const user = await currentUser();
   const services = await getServicesByVendorId(user?.id, page);
-
+  // console.log('services: ', JSON.stringify(services, null, 2));
 
   if ("message" in services) {
     throw new Error(services.message);
@@ -30,7 +30,11 @@ export default async function VendorListings({
             <ListingHeader />
           </div>
           {/* TODO: Improve the Loading Services aka use Skeleton loader?  */}
-          <Suspense fallback={<p className="font-semibold text-black">Loading services...</p>}>
+          <Suspense
+            fallback={
+              <p className="font-semibold text-black">Loading services...</p>
+            }
+          >
             {!services?.count ? (
               <div className="mx-auto max-w-7xl grow px-6 lg:px-8">
                 <EmptyListings />
@@ -42,7 +46,11 @@ export default async function VendorListings({
             )}
           </Suspense>
           {/* TODO: Improve the loading pagination as well, maybe a skeleton as well */}
-          <Suspense fallback={<p className="font-semibold text-black">Loading pagination...</p>}>
+          <Suspense
+            fallback={
+              <p className="font-semibold text-black">Loading pagination...</p>
+            }
+          >
             <div className="flex-none">
               <ListingPagination
                 count={services.count}

--- a/src/app/(routes)/vendor/listings/service-editor/_hooks/useUploadImages.ts
+++ b/src/app/(routes)/vendor/listings/service-editor/_hooks/useUploadImages.ts
@@ -10,23 +10,6 @@ import { reduceErrorCodes } from "@/utils/reduce-error-codes";
 import { toast } from "sonner";
 import { useDropzone } from "react-dropzone";
 
-/*
-TODO: Once we will decide on how to store videos, we will implement video upload functionality
-"video/mp4": [".mp4"],
-"video/quicktime": [".mov"],
-"video/avi": [".avi"],
-"video/x-msvideo": [".avi"],
-"video/x-flv": [".flv"],
-"video/x-matroska": [".mkv"],
-"video/x-ms-wmv": [".wmv"],
-"video/x-ms-asf": [".asf"],
-"video/x-mpeg": [".mpeg"],
-"video/x-ogm": [".ogm"],
-"video/3gpp": [".3gp"],
-"video/3gpp2": [".3g2"],
-"video/ogg": [".ogg"],
-"video/webm": [".webm"],
-*/
 export const useUploadImages = () => {
   const [uploadedFiles, setUploadedFiles] = useState<
     (File | S3File | CustomSwellFile | null)[]
@@ -52,7 +35,7 @@ export const useUploadImages = () => {
             duration: 15000,
             closeButton: true,
             position: "top-right",
-          }
+          },
         );
         return;
       }
@@ -63,12 +46,10 @@ export const useUploadImages = () => {
           const nonNullFiles = oldFiles.filter((file) => file !== null);
 
           if (nonNullFiles.length === 10) {
-            // console.log(`we already have 10 files`);
             return [...oldFiles];
           }
 
           if (nonNullFiles.length + acceptedFiles.length < 10) {
-            // console.log(`we still have less than 10 files`);
             return [
               ...nonNullFiles,
               ...acceptedFiles,
@@ -79,7 +60,6 @@ export const useUploadImages = () => {
           }
 
           if (nonNullFiles.length + acceptedFiles.length === 10) {
-            // console.log(`we have 10 files between uploaded and accepted files`);
             return [...nonNullFiles, ...acceptedFiles];
           }
 
@@ -89,14 +69,14 @@ export const useUploadImages = () => {
         // upload the files to AWS S3 bucket
         const appendedFiles = appendMultipleFilesToFormData(
           "files",
-          acceptedFiles
+          acceptedFiles,
         );
 
         const filesSavedInS3 = await uploadFilesToAmazonS3(appendedFiles);
         // save the files in Swell after uploading to S3
         const savedS3Files = appendMultipleFilesToFormData(
           "files",
-          filesSavedInS3
+          filesSavedInS3,
         );
 
         const filesSavedInSwell = await saveUploadedFilesInSwell(savedS3Files);
@@ -111,12 +91,12 @@ export const useUploadImages = () => {
               duration: 15000,
               closeButton: true,
               position: "top-right",
-            }
+            },
           );
         } else {
           setUploadedFiles((prevFiles) => {
             const filesToKeep = prevFiles.filter(
-              (file) => file !== null && !(file instanceof File)
+              (file) => file !== null && !(file instanceof File),
             );
 
             return [

--- a/src/app/_lib/create-product-draft.ts
+++ b/src/app/_lib/create-product-draft.ts
@@ -12,7 +12,7 @@ export const createProductDraft = async (productData: Product) => {
     virtual: true,
     vendor_id: productData.vendor_id,
     content: {
-      s3files_id: productData.s3files_id,
+      s3files_id: productData.content.s3files_id,
     },
   });
 

--- a/src/app/_lib/getS3Files.ts
+++ b/src/app/_lib/getS3Files.ts
@@ -1,0 +1,29 @@
+import type { CustomSwellFile, SwellResponse } from "@/types/index";
+
+import { getErrorMessage } from "@/utils/get-error-message";
+import swell from "@/lib/server";
+
+export const getS3Files = async (
+  arr: string[],
+): Promise<SwellResponse<CustomSwellFile> | string> => {
+  // error if the array is empty or is not an array
+  if (!Array.isArray(arr) || !arr.length) {
+    throw new Error("Invalid S3 File IDs provided.");
+  }
+
+  if (arr.length > 100) {
+    throw new Error(
+      "Too many S3 File IDs provided. Please provide up to 10 ids.",
+    );
+  }
+
+  try {
+    return await swell.get(`/content/s-3-files`, {
+      where: {
+        id: { $in: arr },
+      },
+    });
+  } catch (error) {
+    return getErrorMessage(error);
+  }
+};

--- a/src/app/_lib/schema.ts
+++ b/src/app/_lib/schema.ts
@@ -46,10 +46,6 @@ export const ServiceListingSchema = z.object({
   uploaded_service_files: z.string().transform((val, ctx) => {
     try {
       const parsedUploadedFiles = JSON.parse(val);
-      console.log(
-        "parsedUploadedFiles in Services schema: ",
-        parsedUploadedFiles
-      );
 
       if (!Array.isArray(parsedUploadedFiles)) {
         ctx.addIssue({

--- a/src/app/_types/index.ts
+++ b/src/app/_types/index.ts
@@ -234,9 +234,12 @@ export interface Product {
   type?: string;
   active: boolean;
   images?: SwellProductImage[];
-  s3files_id: string[];
   purchase_options?: PurchaseOptions;
   variable?: boolean;
+  content: {
+    s3files_id: string[];
+  };
+  s3Images: CustomSwellFile[];
   description: string;
   tags?: string[];
   meta_title?: null | string;

--- a/src/app/_types/index.ts
+++ b/src/app/_types/index.ts
@@ -239,7 +239,7 @@ export interface Product {
   content: {
     s3files_id: string[];
   };
-  s3Images: CustomSwellFile[];
+  s3Images?: CustomSwellFile[];
   description: string;
   tags?: string[];
   meta_title?: null | string;


### PR DESCRIPTION
Actually, there was no need to associate each one of the uploaded Files to a specific Product (called Service). This is because when retrieiving Products there's no way to find out ahead of time the IDs of the uploaded files associated to the products. So, what's best in this case, is once the product(s) are retrieved we have the IDs of these files, and we can use the powerful queries `where` and `$in` to bring these to the product by IDs.